### PR TITLE
Issue #6 Added Ability To Have Conditional Rules In Contract

### DIFF
--- a/Flunt.Tests/ConditionalValidationContractTests.cs
+++ b/Flunt.Tests/ConditionalValidationContractTests.cs
@@ -1,0 +1,82 @@
+using Fluent.Tests.Entities;
+using Flunt.Validations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Flunt.Tests
+{
+    [TestClass]
+    public class ConditionalValidationContractTests
+    {
+        private Dummy _dummy;
+
+        [TestMethod]
+        [TestCategory("ConditionalValidation")]
+        public void IfNotNullForString()
+        {
+            _dummy = new Dummy();
+            _dummy.stringProp = "abc";
+
+            var wrong = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(1, wrong.Notifications.Count);
+
+            _dummy.stringProp = "1234";
+            
+            var right = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"))
+                .IfNotNull(_dummy.stringProp, x => x.HasMinLen(_dummy.stringProp, 1, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(true, right.Valid);
+        }
+        
+        [TestMethod]
+        [TestCategory("ConditionalValidation")]
+        public void IfNotNullForNullableInt()
+        {
+            _dummy = new Dummy();
+            _dummy.nullableIntProp = 1;
+
+            var wrong = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.nullableIntProp, x => x.IsGreaterOrEqualsThan(_dummy.nullableIntProp.Value, 5, nameof(_dummy.nullableIntProp), "Property should be greater or equal than given value if not null"));
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(1, wrong.Notifications.Count);
+
+            _dummy.nullableIntProp = null;
+            
+            var right = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.nullableIntProp, x => x.IsGreaterOrEqualsThan(_dummy.nullableIntProp.Value, 5, nameof(_dummy.nullableIntProp), "Property should be greater or equal than given value if not null"));
+
+            Assert.AreEqual(true, right.Valid);
+        }
+        
+        [TestMethod]
+        [TestCategory("ConditionalValidation")]
+        public void IfNotNullForObject()
+        {
+            _dummy = new Dummy();
+            _dummy.objectProp = "some other object";
+
+            var wrong = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.objectProp, x => x.AreEquals(_dummy.objectProp, "some object", nameof(_dummy.objectProp), "Property should be equal if not null"));
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(1, wrong.Notifications.Count);
+
+            _dummy.objectProp = null;
+            
+            var right = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.objectProp, x => x.AreEquals(_dummy.objectProp, "some object", nameof(_dummy.objectProp), "Property should be equal if not null"));
+
+            Assert.AreEqual(true, right.Valid);
+        }
+    }
+}

--- a/Flunt.Tests/Entities/Dummy.cs
+++ b/Flunt.Tests/Entities/Dummy.cs
@@ -15,5 +15,6 @@ namespace Fluent.Tests.Entities
         public DateTime dateTimeProp {get;set;}
         public Guid guidProp {get;set;}
         public TimeSpan timeSpanProp { get; set; }
+        public int? nullableIntProp { get; set; }
     }
 }

--- a/Flunt/Validations/Contract.cs
+++ b/Flunt/Validations/Contract.cs
@@ -1,4 +1,6 @@
-﻿using Flunt.Notifications;
+﻿using System;
+using System.Linq.Expressions;
+using Flunt.Notifications;
 
 namespace Flunt.Validations
 {
@@ -20,6 +22,16 @@ namespace Flunt.Validations
                 }
             }
 
+            return this;
+        }
+        
+        public Contract IfNotNull(object parameterType, Expression<Func<Contract, Contract>> contractExpression)
+        {
+            if (parameterType != null)
+            {
+                contractExpression.Compile().Invoke(this);
+            }
+            
             return this;
         }
     }


### PR DESCRIPTION
It resolves the issue : https://github.com/andrebaltieri/flunt/issues/6

Desired example use case in issue:

Contract.Required().IfNotNull(x.LastName, contract => contract.MinLength(3));

Implemented feature :

_dummy = new Dummy();
_dummy.stringProp = "abc";

var wrong = new Contract()
    .Requires()
    .IfNotNull(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"));