### PR TITLE
Strings can be null or empty, but if it's not, specific length is needed

### DIFF
--- a/Flunt.Tests/StringValidationContractTests.cs
+++ b/Flunt.Tests/StringValidationContractTests.cs
@@ -27,7 +27,7 @@ namespace Flunt.Tests
         [TestMethod]
         [TestCategory("StringValidation")]
         public void IsNotNullOrWhiteSpace()
-        {                                
+        {
             var wrong = new Contract()
                 .Requires()
                 .IsNotNullOrWhiteSpace(null, "string", "String is Null")
@@ -228,6 +228,72 @@ namespace Flunt.Tests
             Assert.AreEqual(true, right.Valid);
         }
 
+        [TestMethod]
+        [TestCategory("StringValidation")]
+        public void HasMinLengthIfNotNullOrEmpty()
+        {
+            var errorMessage = "String not null or empty and length is less than permitted";
+            var wrong = new Contract()
+                .Requires()
+                .HasMinLengthIfNotNullOrEmpty("123456789", 10, "string", errorMessage)
+                .HasMinLengthIfNotNullOrEmpty("         ", 10, "string", errorMessage);
 
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(2, wrong.Notifications.Count);
+
+            var right = new Contract()
+                .Requires()
+                .HasMinLengthIfNotNullOrEmpty(null, 10, "string", errorMessage)
+                .HasMinLengthIfNotNullOrEmpty("", 10, "string", errorMessage)
+                .HasMinLengthIfNotNullOrEmpty("1234567890", 10, "string", errorMessage)
+                .HasMinLengthIfNotNullOrEmpty("123456789012345", 10, "string", errorMessage);
+
+            Assert.AreEqual(true, right.Valid);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
+        public void HasMaxLengthIfNotNullOrEmpty()
+        {
+            var errorMessage = "String not null or empty and length is more than permitted";
+            var wrong = new Contract()
+                .Requires()
+                .HasMaxLengthIfNotNullOrEmpty("123456789012345", 10, "string", errorMessage)
+                .HasMaxLengthIfNotNullOrEmpty("               ", 10, "string", errorMessage);
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(2, wrong.Notifications.Count);
+
+            var right = new Contract()
+                .Requires()
+                .HasMaxLengthIfNotNullOrEmpty(null, 10, "string", errorMessage)
+                .HasMaxLengthIfNotNullOrEmpty("", 10, "string", errorMessage)
+                .HasMaxLengthIfNotNullOrEmpty("12345", 10, "string", errorMessage)
+                .HasMaxLengthIfNotNullOrEmpty("1234567890", 10, "string", errorMessage);
+
+            Assert.AreEqual(true, right.Valid);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
+        public void HasExactLengthIfNotNullOrEmpty()
+        {
+            var errorMessage = "String not null or empty and length is different than permitted";
+            var wrong = new Contract()
+                .Requires()
+                .HasExactLengthIfNotNullOrEmpty("123456789", 10, "string", errorMessage)
+                .HasExactLengthIfNotNullOrEmpty("12345678901", 10, "string", errorMessage);
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(2, wrong.Notifications.Count);
+
+            var right = new Contract()
+                .Requires()
+                .HasExactLengthIfNotNullOrEmpty(null, 10, "string", errorMessage)
+                .HasExactLengthIfNotNullOrEmpty("", 10, "string", errorMessage)
+                .HasExactLengthIfNotNullOrEmpty("1234567890", 10, "string", errorMessage);
+
+            Assert.AreEqual(true, right.Valid);
+        }
     }
 }

--- a/Flunt/Validations/StringValidationContract.cs
+++ b/Flunt/Validations/StringValidationContract.cs
@@ -122,6 +122,28 @@ namespace Flunt.Validations
             return Matchs(text, pattern, property, message);
         }
 
+        public Contract HasMinLengthIfNotNullOrEmpty(string text, int min, string property, string message)
+        {
+            if (!string.IsNullOrEmpty(text) && text.Length < min)
+                AddNotification(property, message);
 
+            return this;
+        }
+
+        public Contract HasMaxLengthIfNotNullOrEmpty(string text, int max, string property, string message)
+        {
+            if (!string.IsNullOrEmpty(text) && text.Length > max)
+                AddNotification(property, message);
+
+            return this;
+        }
+
+        public Contract HasExactLengthIfNotNullOrEmpty(string text, int len, string property, string message)
+        {
+            if (!string.IsNullOrEmpty(text) && text.Length != len)
+                AddNotification(property, message);
+
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Rules added for optional string fields, but if it's not null or empty, some specific length is required (minimum, maximum or exact).

`var someStr = "test";`
`var wrong = new Contract().HasMinLengthIfNotNullOrEmpty(someStr, 10, "string property", "10 characters is the minimum length if string is not null or empty");`
`var right  = new Contract().HasMinLengthIfNotNullOrEmpty(someStr, 3, "string property", "3 characters is the minimum length if string is not null or empty");` 
`var rightAgain  = new Contract().HasMinLengthIfNotNullOrEmpty(null, 3, "string property", "3 characters is the minimum length if string is not null or empty");` 
