### PR TITLE
Conditional IfNotNullOrEmpty in StringValidationContract

### DIFF
--- a/Flunt.Tests/ConditionalValidationContractTests.cs
+++ b/Flunt.Tests/ConditionalValidationContractTests.cs
@@ -24,15 +24,23 @@ namespace Flunt.Tests
             Assert.AreEqual(1, wrong.Notifications.Count);
 
             _dummy.stringProp = "1234";
-            
+
             var right = new Contract()
                 .Requires()
                 .IfNotNull(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"))
                 .IfNotNull(_dummy.stringProp, x => x.HasMinLen(_dummy.stringProp, 1, nameof(_dummy.stringProp), "Property should be digit if not null"));
 
             Assert.AreEqual(true, right.Valid);
+
+            _dummy.nullableIntProp = null;
+
+            var rightNull = new Contract()
+                .Requires()
+                .IfNotNull(_dummy.nullableIntProp, x => x.IsGreaterOrEqualsThan(_dummy.nullableIntProp.Value, 5, nameof(_dummy.nullableIntProp), "Property should be greater or equal than given value if not null"));
+
+            Assert.AreEqual(true, rightNull.Valid);
         }
-        
+
         [TestMethod]
         [TestCategory("ConditionalValidation")]
         public void IfNotNullForNullableInt()
@@ -48,14 +56,14 @@ namespace Flunt.Tests
             Assert.AreEqual(1, wrong.Notifications.Count);
 
             _dummy.nullableIntProp = null;
-            
+
             var right = new Contract()
                 .Requires()
                 .IfNotNull(_dummy.nullableIntProp, x => x.IsGreaterOrEqualsThan(_dummy.nullableIntProp.Value, 5, nameof(_dummy.nullableIntProp), "Property should be greater or equal than given value if not null"));
 
             Assert.AreEqual(true, right.Valid);
         }
-        
+
         [TestMethod]
         [TestCategory("ConditionalValidation")]
         public void IfNotNullForObject()
@@ -71,7 +79,7 @@ namespace Flunt.Tests
             Assert.AreEqual(1, wrong.Notifications.Count);
 
             _dummy.objectProp = null;
-            
+
             var right = new Contract()
                 .Requires()
                 .IfNotNull(_dummy.objectProp, x => x.AreEquals(_dummy.objectProp, "some object", nameof(_dummy.objectProp), "Property should be equal if not null"));

--- a/Flunt.Tests/StringValidationContractTests.cs
+++ b/Flunt.Tests/StringValidationContractTests.cs
@@ -1,3 +1,4 @@
+using Fluent.Tests.Entities;
 using Flunt.Validations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -331,6 +332,47 @@ namespace Flunt.Tests
                 .Requires()
                 .AreEquals("String", "String", "string", "String are equals");
             Assert.AreEqual(true, right.Valid);
+        }
+
+        [TestMethod]
+        [TestCategory("StringConditionalValidation")]
+        public void IfNotNullOrEmpty()
+        {
+            var _dummy = new Dummy();
+
+            _dummy.stringProp = "abc";
+
+            var wrong = new Contract()
+                .Requires()
+                .IfNotNullOrEmpty(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(1, wrong.Notifications.Count);
+
+            _dummy.stringProp = "1234";
+
+            var right = new Contract()
+                .Requires()
+                .IfNotNullOrEmpty(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"))
+                .IfNotNullOrEmpty(_dummy.stringProp, x => x.HasMinLen(_dummy.stringProp, 1, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(true, right.Valid);
+
+            _dummy.stringProp = "";
+
+            var rightEmpty = new Contract()
+                .Requires()
+                .IfNotNullOrEmpty(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(true, rightEmpty.Valid);
+
+            _dummy.stringProp = null;
+
+            var rightNull = new Contract()
+                .Requires()
+                .IfNotNullOrEmpty(_dummy.stringProp, x => x.IsDigit(_dummy.stringProp, nameof(_dummy.stringProp), "Property should be digit if not null"));
+
+            Assert.AreEqual(true, rightNull.Valid);
         }
     }
 }

--- a/Flunt/Validations/StringValidationContract.cs
+++ b/Flunt/Validations/StringValidationContract.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Linq;
-using System.Text.RegularExpressions;	
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 
 namespace Flunt.Validations
 {
@@ -143,6 +143,15 @@ namespace Flunt.Validations
             if (!string.IsNullOrEmpty(text) && text.Length != len)
                 AddNotification(property, message);
 
+            return this;
+        }
+
+        public Contract IfNotNullOrEmpty(string parameterType, Expression<Func<Contract, Contract>> contractExpression)
+        {
+            if (!string.IsNullOrEmpty(parameterType))
+            {
+                contractExpression.Compile().Invoke(this);
+            }
             return this;
         }
     }


### PR DESCRIPTION
Precisei validar um e-mail, mas somente se ele tivesse alguma string pra validá-lo. Ao invés de criar um IsEmailIfNotNullOrEmpty (seguindo o padrão HasExactLengthIfNotNullOrEmpty), acho que fica melhor criar um genérico e usar ele ao invés de criar um pra cada validação.

Além disso coloquei um teste em IfNotNull pra testar que não daria erro se tivesse nulo.