### PR TITLE
Creating standardized return notifications

### DIFF
--- a/Flunt/Notifications/Notifiable.cs
+++ b/Flunt/Notifications/Notifiable.cs
@@ -11,6 +11,18 @@ namespace Flunt.Notifications
 
         public IReadOnlyCollection<Notification> Notifications => _notifications;
 
+        public List<string> NotificationsToList()
+        {
+            List<string> lista = new List<string>();
+
+            lista.Clear();
+            foreach (var item in Notifications)
+            {
+                lista.Add(item.Property +  ": " + item.Message);
+            }
+            return lista;
+        }
+        
         public void AddNotification(string property, string message)
         {
             _notifications.Add(new Notification(property, message));


### PR DESCRIPTION
Creation of functionality to return validation failures in the following pattern:
`[`
`    "property 1": "failure"`
`    "property 2": "failure"`
`    ...`
`]`