### PR TITLE
Creating standardized return notifications

### DIFF
--- a/Flunt/Notifications/Notifiable.cs
+++ b/Flunt/Notifications/Notifiable.cs
@@ -11,6 +11,11 @@ namespace Flunt.Notifications
 
         public IReadOnlyCollection<Notification> Notifications => _notifications;
 
+        public List<string> NotificationsToList()
+        {
+            return Notifications.Select(n => $"{n.Property}: {n.Message}").ToList();
+        }
+        
         public void AddNotification(string property, string message)
         {
             _notifications.Add(new Notification(property, message));


### PR DESCRIPTION
Creation of functionality to return validation failures in the following pattern:
[
    "property 1": "failure"
    "property 2": "failure"
...
]

Refactoring: https://github.com/andrebaltieri/flunt/pull/43