### PR TITLE
Update readme in order to informate about fluntbr

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ https://docs.microsoft.com/pt-br/dotnet/standard/net-standard
 ## Instalation
 This package is available through Nuget Packages: https://www.nuget.org/packages/Flunt
 
+Note: For Brazilian validations like (CPF, CNPJ) you also need to install another lib with the necessary extensions: https://github.com/lira92/flunt.br
+
 **Nuget**
 ```
 Install-Package Flunt


### PR DESCRIPTION
this change is in order to let devs know about the Brazilian lib called Flunt.Br, that has the main objective to validate some rules exclusives from Brazil like cnpj or cpf.