### PR TITLE
Making AreEquals and AreNotEquals contracts null safe

### DIFF
--- a/Flunt.Tests/StringValidationContractTests.cs
+++ b/Flunt.Tests/StringValidationContractTests.cs
@@ -320,15 +320,17 @@ namespace Flunt.Tests
         {
             var wrong = new Contract()
                 .Requires()
-                .IsNotNullOrEmpty(null, "string", "String is Null")
-                .IsNotNullOrEmpty("", "string", "String is Empty");
+                .AreEquals(null, "String not equals", "string", "String are not equals")
+                .AreEquals("", "String not equals", "string", "String are not equals")
+                .AreEquals("String almost equals", "String almolst equals", "string", "String are not equals");
 
-            Assert.AreEqual(false, wrong.Valid);
-            Assert.AreEqual(2, wrong.Notifications.Count);
+            Assert.IsFalse(wrong.Valid);
+            Assert.AreEqual(3, wrong.Notifications.Count);
 
             var right = new Contract()
                 .Requires()
-                .IsNotNullOrEmpty("Some valid string", "string", "String is Null");
+                .AreEquals("Some valid string", "Some valid string", "string", "String are equals");
+
             Assert.AreEqual(true, right.Valid);
         }
 
@@ -339,16 +341,18 @@ namespace Flunt.Tests
         {
             var wrong = new Contract()
                 .Requires()
-                .AreEquals("String", "String not equals", "string", "String are not equals")
-                .AreNotEquals("String", "String", "string", "String are equals");
+                .AreNotEquals("Some valid string", "Some valid string", "string", "String are equals");
 
-            Assert.AreEqual(false, wrong.Valid);
-            Assert.AreEqual(2, wrong.Notifications.Count);
+            Assert.IsFalse(wrong.Valid);
+            Assert.AreEqual(1, wrong.Notifications.Count);
 
             var right = new Contract()
                 .Requires()
-                .AreEquals("String", "String", "string", "String are equals");
-            Assert.AreEqual(true, right.Valid);
+                .AreNotEquals(null, "String not equals", "string", "String are not equals")
+                .AreNotEquals("", "String not equals", "string", "String are not equals")
+                .AreNotEquals("String almost equals", "String almolst equals", "string", "String are not equals");
+
+            Assert.IsTrue(right.Valid);
         }
 
         [TestMethod]

--- a/Flunt/Validations/StringValidationContract.cs
+++ b/Flunt/Validations/StringValidationContract.cs
@@ -66,7 +66,7 @@ namespace Flunt.Validations
 
         public Contract AreEquals(string val, string text, string property, string message, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
         {
-            if (!val.Equals(text, comparisonType))
+            if (!string.Equals(val, text, comparisonType))
                 AddNotification(property, message);
 
             return this;
@@ -74,7 +74,7 @@ namespace Flunt.Validations
 
         public Contract AreNotEquals(string val, string text, string property, string message, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
         {
-            if (val.Equals(text, comparisonType))
+            if (string.Equals(val, text, comparisonType))
                 AddNotification(property, message);
 
             return this;


### PR DESCRIPTION
On the methods AreEquals and AreNotEqual in the class [Flunt/Validations/StringValidationContract.cs](https://github.com/andrebaltieri/flunt/pull/64/files#diff-9505edbdc23083e45b56c2ba78dddce2b75f5c3494e6b227503aa7cae3a535ca)
there ia a little problem in a specific situation:

When the [instance Equals method](https://referencesource.microsoft.com/#mscorlib/system/string.cs,526) was called, you can get an `NullReferenceException` if the 
specified property value was `null`.

To avoid this behavior, I am suggesting the use of [static string.Equals](https://referencesource.microsoft.com/#mscorlib/system/string.cs,594) instead it. So `null` values wil be considered different without throws any unexpect exception.


